### PR TITLE
http and gzip spec proposal

### DIFF
--- a/protocol_ids.csv
+++ b/protocol_ids.csv
@@ -1,8 +1,0 @@
-Prefix,DisplayName,Authors,BitcoinAddress,SpecificationUrl,TxidRedirectUrl
-0x00000020,Tokenized,James Belding,14G5z9kbACK9SiSgZnZmgpxn7aetBUD5vY,http://tokenized.cash/,
-0x00555354,UniSOT,Stephan Nilsson,12L7P3J6LySz2DtGS7vrrnbYAPKcZf8kiu,http://unisot.io/ust,
-0x00584350,Counterparty Cash,Counterparty Cash Association (CCA),17YhxKgKunLjvi7HB1ENGmeLwPFiaxb74V,https://counterparty.cash,
-0x00746C6B,Keyport,Keyport,,https://keyport.io,
-0x02446365,SatoshiDICE,Jon Bestman,1DiceuELb5GZktc3CMEv868DMtU3B5957x,https://satoshidice.com,
-0xac1eed88,Miner ID,Steve Shadders,,,
-0xff000000,extended protocol id mask,,,,

--- a/protocols/01-http.md
+++ b/protocols/01-http.md
@@ -1,0 +1,20 @@
+# HTTP in OP_RETURN
+
+Protocol identifier: `0x68747470`
+
+## Specification
+
+The protocol identfier is a `PUSHDATA` data element `0x04 0x68747470` which is the 1 byte length prefix followed by the 4 byte identifier which translates to the ASCII string `http`.
+
+This should be followed by a two further `PUSHDATA` data elements: `<headers> <body>`
+
+### Headers 
+
+Should contain a set of valid HTTP headers encoded as JSON.  Repeated keys are support by the value being encoded as a JSON array of elements.
+
+headers are typically used to specfiy content type and encoding.
+
+### Body 
+Should contain the document body as specified by the content-type in the header.
+
+

--- a/protocols/02-gzip.md
+++ b/protocols/02-gzip.md
@@ -1,0 +1,46 @@
+# GZIP protocol identifier
+
+Protocol identifier: `0x677a6970`
+
+## Specification
+
+The protocol identfier is a `PUSHDATA` data element `0x04 0x677a6970` which is the 1 byte length prefix followed by the 4 byte identifier which translates to the ASCII string `gzip`.
+
+The `gzip` protocol identifier is intended to markup another `OP_RETURN` based protocol by adding the simple rule:
+
+If the `gzip` identifier is present the following `PUSHDATA` operation contains gzip encoded data.  The only exception is the very first `gzip` identifier which is used to designate that the gzip handler should parse all the `PUSHDATA` following according to the above rule.  To push a single gzipped data element the protocol identifier should be pushed twice followed by the gzipped data.
+
+The second `PUSHDATA`following the gzip protocol identfier should also be interpreted as a protocol identfier.  In order to be interpreted according to the original protocol any data elements marked as gzipped should be decompressed and the gzip identifiers stripped out.
+
+This protocol is stream friendly and can be implemented as a pipeline of stream handlers: `gzip_handler -> sub_handler`
+
+Examples 
+
+##### Gzip a single data element: 
+
+`<gzip> <gzip> <data_gz>`
+
+Which should be returned from the gzip handler as:
+
+`<data>`
+
+
+##### Compressed HTTP body but uncompressed headers:
+
+`<gzip> <http> <headers> <gzip> <body_gz>`
+
+This should be passed to the gzip handler which should output:
+
+`<http ><header> <body>`
+
+Which is then passed to the http protocol handler.
+
+##### Compressed HTTP headers and body:
+
+`<gzip> <http> <gzip> <header_gz> <gzip> <body_gz>`
+
+This should be passed to the gzip handler which should output:
+
+`<http> <header> <body>`
+
+Which is then passed to the http protocol handler.


### PR DESCRIPTION
This is a basic standard proposal for encoding http element as a two data chunks, <headers> <body>.  The headers are JSON encoded but otherwise identical HTTP headers.  This allows content-type, encoding and other meta data to be described so that OP_RETURN viewing tools can easily determine how to display the contained data.  This enables html, js, css, json, images and other binary files to be easily represented.

An addition spec for defining data elements as GZIP encoded is also included.  This can extend the HTTP protocol to indicate that headers or body (or both) are gzip encoded.  HTTP can also specify this using HTTP headers but there is no way to do this for the header without making the HTTP protocol itself more complex.  The GZIP protocol neatly overlays it and is easily applicable to any other protocol that uses framed data elements.