### PR TITLE
File data meta gzip generic versioning

### DIFF
--- a/protocols/4.0-Versioning.md
+++ b/protocols/4.0-Versioning.md
@@ -1,9 +1,0 @@
-# Versioning in OP_RETURN
-
-Protocols can implement versioning by chaining based upon a private key per version that is issued in an OP_RETURN.
-
-## Proposal
-
-A new, optional, data element `<version-key>` is provided. This is public key derived from a private key known to the publisher of the OP_RETURN.
-
-A second data element `<prior-version-key>` is required when issuing a transaction that increments the version number of the OP_RETURN. This key matches the previous transaction's `<version-key>` and the new OP_RETURN also provides its own `<version-key>`. This new `<version-key>` is derived from the private key for the prior version's OP_RETURN, and can be verified as a valid version increment by an explorer or protocol interpretation engine.


### PR DESCRIPTION
I'd like to open up a proposal for versioning of data in OP_RETURN, using two new optional elements that allow a chain of OP_RETURNS to be identified by clients. 

With the right kind of crypto I believe it is possible for a publisher to authenticate each newly published version. This allows clients to reject OP_RETURNS that purport to be new versions if they do not provide the correct elements. But IANAC (I am not a cryptographer) so I'm assuming that this chain based on pairs of keys will work.

Essentially the publisher of an OP_RETURN adds a key which allows them to "spend" the OP_RETURN with a replacement (new version) OP_RETURN, which also provides a new key that they can spend later.

There may be a requirement to allow version-forking (versions 2 and 3 can exist both forked from version 1). I don't want to go deep into that, because I'm initially interested in whether versioning is seen as worthwhile.